### PR TITLE
Remove PHP requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,7 @@
 {
     "name": "classyllama/module-owlcarousel",
     "description": "OwlCarousel JS package for Magento 2",
-    "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0"
-    },
+    "require": {},
     "type": "magento2-module",
     "version": "2.2.0",
     "license": [


### PR DESCRIPTION
This extension isn't compatible with PHP 7.1 due to composer.json requirements.

Considering that most 2.2+ sites will be using PHP 7.1+, this makes a big difference.

Since the extension is essentially all javascript, I'm proposing that the PHP version constraint be removed entirely, rather than adding 7.1 and 7.2 to the list.