### PR TITLE
Remove PHP requirement in composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ClassyLlama OwlCarousel Module for Magento 2
 
+!x This repository is no longer supported or maintained, and has been archived.
+
+
 This package makes the JavaScript library [OwlCarousel](https://github.com/OwlCarousel2/OwlCarousel2) available as an M2 module.
 
 Note that this version of OwlCarousel is UMD compliant per [this fork](https://github.com/classyllama/OwlCarousel2).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ClassyLlama OwlCarousel Module for Magento 2
 
-!x This repository is no longer supported or maintained, and has been archived.
+
+> **This repository is no longer supported or maintained, and has been archived.**
 
 
 This package makes the JavaScript library [OwlCarousel](https://github.com/OwlCarousel2/OwlCarousel2) available as an M2 module.

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,7 @@
 {
     "name": "classyllama/module-owlcarousel",
     "description": "OwlCarousel JS package for Magento 2",
-    "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0"
-    },
+    "require": {},
     "type": "magento2-module",
     "version": "2.2.0",
     "license": [


### PR DESCRIPTION
This extension isn't compatible with PHP 7.1 due to composer.json requirements.

Considering that most 2.2+ sites will be using PHP 7.1+, this makes a big difference.

Since the extension is essentially all javascript, I'm proposing that the PHP version constraint be removed entirely, rather than adding 7.1 and 7.2 to the list.